### PR TITLE
Fix issue #6

### DIFF
--- a/lib/ccv.js
+++ b/lib/ccv.js
@@ -124,8 +124,15 @@ var ccv = module.exports = exports = {
       var scale = params.scale;
       var next = params.next;
       var scale_upto = params.scale_upto;
-      var pyr = new Array((scale_upto + next * 2) * 4);
-      var ret = new Array((scale_upto + next * 2) * 4);
+      var pyr_length = (scale_upto + next * 2) * 4;
+      var pyr, ret;
+      if (pyr_length > 0) {
+        pyr = new Array(pyr_length);
+        ret = new Array(pyr_length);
+      } else {
+        pyr = new Array(next * 8);
+        ret = new Array(next * 8);
+      }
       pyr[0] = canvas;
       ret[0] = { "width" : pyr[0].width,
              "height" : pyr[0].height,


### PR DESCRIPTION
Images with small sizes (< cascade's dimensions) don't crash it
anymore.